### PR TITLE
PHPUnit 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"phing/phing": "^2.16.0",
 		"phpstan/phpstan-phpunit": "^0.10",
 		"phpstan/phpstan-strict-rules": "^0.10",
-		"phpunit/phpunit": "^6.4",
+		"phpunit/phpunit": "^7.0",
 		"slevomat/coding-standard": "^3.3.0"
 	},
 	"autoload": {


### PR DESCRIPTION
@ondrejmirtes As we minimum [require PHP 7.1](https://github.com/phpstan/phpstan-php-parser/blob/master/composer.json#L13), should I remove PHP 7.0 from Travis CI?