### PR TITLE
chore: Use the latest PHPUnit wherever possible, use PHP 8.0 for PHPCS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,9 @@ jobs:
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress --no-suggest"
 
-      - name: "Update PHPUnit"
-        if: matrix.php-version == '7.4' || matrix.php-version == '8.0'
-        run: "composer require --dev phpunit/phpunit:'^9.5' --update-with-dependencies"
-
+      - name: "Downgrade PHPUnit"
+        if: matrix.php-version == '7.1' || matrix.php-version == '7.2' || matrix.php-version == '7.3'
+        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "Lint"
         run: "make lint"
@@ -59,7 +58,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "7.4"
+          php-version: "8.0"
 
       - name: "Validate Composer"
         run: "composer validate"
@@ -108,9 +107,9 @@ jobs:
         if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress --no-suggest"
 
-      - name: "Update PHPUnit"
-        if: matrix.php-version == '7.4' || matrix.php-version == '8.0'
-        run: "composer require --dev phpunit/phpunit:'^9.5' --update-with-dependencies"
+      - name: "Downgrade PHPUnit"
+        if: matrix.php-version == '7.1' || matrix.php-version == '7.2' || matrix.php-version == '7.3'
+        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "Tests"
         run: "make tests"
@@ -152,9 +151,9 @@ jobs:
         if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress --no-suggest"
 
-      - name: "Update PHPUnit"
-        if: matrix.php-version == '7.4' || matrix.php-version == '8.0'
-        run: "composer require --dev phpunit/phpunit:'^9.5' --update-with-dependencies"
+      - name: "Downgrade PHPUnit"
+        if: matrix.php-version == '7.1' || matrix.php-version == '7.2' || matrix.php-version == '7.3'
+        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "PHPStan"
         run: "make phpstan"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpstan/phpstan-phpunit": "^0.12.16",
 		"phpstan/phpstan-strict-rules": "^0.12.6",
-		"phpunit/phpunit": "^7.5.20"
+		"phpunit/phpunit": "^9.5"
 	},
 	"config": {
 		"platform": {


### PR DESCRIPTION
See https://github.com/phpstan/phpstan-symfony/pull/162
